### PR TITLE
unit test syntax conversion and fix

### DIFF
--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testAddition.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testAddition.st
@@ -1,10 +1,11 @@
 testing
 testAddition
 	| fd |
-
 	fd := FixedDecimal newFromNumber: 18.25 scale: 2.
-	self assert: ('20.00' = (fd + (1.75 asFixedDecimal: 2)) printString).
-	self assert: ('20.00' = (fd + 1.75) printString).
-	self assert: ('20.00' = (fd + (175/100)) printString).
-	self assert: ('19.25' = (fd + 1) printString).
-	self assert: ('17.25' = (fd + -1) printString).
+	self
+		assert: '20.00'
+		equals: (fd + (1.75 asFixedDecimal: 2)) printString.
+	self assert: '20.00' equals: (fd + 1.75) printString.
+	self assert: '20.00' equals: (fd + (175 / 100)) printString.
+	self assert: '19.25' equals: (fd + 1) printString.
+	self assert: '17.25' equals: (fd + -1) printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testAdoption.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testAdoption.st
@@ -1,16 +1,14 @@
 testing
 testAdoption
 	| original |
-	
-	original := (8872240531573379/9007199254740992) asFixedDecimal: 3.
-	self assert: '1.985' = ((1 + original) printString).
-	self assert: '1.985' = ((original + 1) printString).
-	self assert: '1.485' = ((1/2 + original) printString).
-	self assert: '1.485' = ((original + (1/2)) printString).
-	self assert: '1.985' = ((1.0 + original) printString).
-	self assert: '1.985' = ((original + 1.0) printString).
-	self assert: '1.985' = ((1s2 + original) printString).
-	self assert: '1.985' = ((original + 1s2) printString).
-	self assert: '1.985' = (('1' + original) printString).
-	self assert: '1.985' = ((original + '1') printString).
-	
+	original := 8872240531573379 / 9007199254740992 asFixedDecimal: 3.
+	self assert: '1.985' equals: (1 + original) printString.
+	self assert: '1.985' equals: (original + 1) printString.
+	self assert: '1.485' equals: (1 / 2 + original) printString.
+	self assert: '1.485' equals: (original + (1 / 2)) printString.
+	self assert: '1.985' equals: (1.0 + original) printString.
+	self assert: '1.985' equals: (original + 1.0) printString.
+	self assert: '1.985' equals: (1s2 + original) printString.
+	self assert: '1.985' equals: (original + 1s2) printString.
+	self assert: '1.985' equals: (('1' asFixedDecimal: 3) + original) printString.
+	self assert: '1.985' equals: (original + ('1' asFixedDecimal: 3)) printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testConvertFromFloat.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testConvertFromFloat.st
@@ -1,17 +1,13 @@
 testing
 testConvertFromFloat
 	| aFloat fd f2 diff |
-
-	aFloat := 11/13 asFloat.
+	aFloat := 11 / 13 asFloat.
 	fd := FixedDecimal newFromNumber: aFloat scale: 2.
-	self assert: 2 == fd scale.
-	self assert: '0.85' = fd printString. "Note - different than ScaledDecimal.  For ScaledDecimal
-										this will equal 0.84.  Fixed decimals - we actually
-										round to the scale provided - we don't want the 
-										extra precision that ScaledDecimal keeps around!"
-	self assert: 85 == fd part2.
+	self assert: 2 identicalTo: fd scale.
+	self assert: '0.85' equals: fd printString.
+	self assert: 85 identicalTo: fd part2.
 	f2 := fd asFloat.
-	self assert: 0.85 = f2.
+	self assert: 0.85 equals: f2.
 	diff := f2 - aFloat.
-	"self assert: diff < 1.0e-9." "Unlike ScaledDecimal, this is NOT a reversable conversion!"
-	self assert: diff > 1.0e-9.
+	"self assert: diff < 1.0e-9."	"Unlike ScaledDecimal, this is NOT a reversable conversion!"
+	self assert: diff > 1.0e-9

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testConvertFromFraction.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testConvertFromFraction.st
@@ -1,8 +1,7 @@
 testing
 testConvertFromFraction
-
 	| fd |
-	fd := FixedDecimal newFromNumber: (13 / 11) scale: 6.
-	self assert: FixedDecimal == fd class.
-	self assert: ('1.181818' = fd printString).
-	self assert: 6 == fd scale
+	fd := FixedDecimal newFromNumber: 13 / 11 scale: 6.
+	self assert: FixedDecimal identicalTo: fd class.
+	self assert: '1.181818' equals: fd printString.
+	self assert: 6 identicalTo: fd scale

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testConvertFromInteger.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testConvertFromInteger.st
@@ -5,14 +5,14 @@ testConvertFromInteger
 
 	| fd |
 	fd := FixedDecimal newFromNumber: 13 scale: 6.
-	self assert: 6 = fd scale.
-	self assert: ('13.000000' = fd printString).
+	self assert: 6 equals: fd scale.
+	self assert: '13.000000' equals: fd printString.
 	fd := FixedDecimal newFromNumber: -13 scale: 6.
-	self assert: 6 = fd scale.
-	self assert: ('-13.000000' = fd printString).
+	self assert: 6 equals: fd scale.
+	self assert: '-13.000000' equals: fd printString.
 	fd := FixedDecimal newFromNumber: 130000000013 scale: 6.
-	self assert: 6 = fd scale.
-	self assert: ('130000000013.000000' = fd printString).
+	self assert: 6 equals: fd scale.
+	self assert: '130000000013.000000' equals: fd printString.
 	fd := FixedDecimal newFromNumber: -130000000013 scale: 6.
-	self assert: 6 = fd scale.
-	self assert: ('-130000000013.000000' = fd printString)
+	self assert: 6 equals: fd scale.
+	self assert: '-130000000013.000000' equals: fd printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testDivision.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testDivision.st
@@ -1,11 +1,10 @@
 testing
 testDivision
 	| fd |
-
 	fd := FixedDecimal newFromNumber: 18.25 scale: 2.
-	self assert: ('9.13' = (fd / (2 asFixedDecimal: 2)) printString).
-	self assert: ('9.13' = (fd / 2.00) printString).
-	self assert: ('9.13' = (fd / (200/100)) printString).
-	self assert: ('9.13' = (fd / 2) printString).
-	self assert: ('-9.13' = (fd / -2) printString).
-	self assert: ('4.56' = (fd / 4) printString).
+	self assert: '9.13' equals: (fd / (2 asFixedDecimal: 2)) printString.
+	self assert: '9.13' equals: (fd / 2.00) printString.
+	self assert: '9.13' equals: (fd / (200 / 100)) printString.
+	self assert: '9.13' equals: (fd / 2) printString.
+	self assert: '-9.13' equals: (fd / -2) printString.
+	self assert: '4.56' equals: (fd / 4) printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testFractionPart.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testFractionPart.st
@@ -1,4 +1,5 @@
 testing
 testFractionPart
-	
-	self assert: '-0.30' = (-53/10 asFixedDecimal: 2) fractionPart printString
+	self
+		assert: '-0.30'
+		equals: (-53 / 10 asFixedDecimal: 2) fractionPart printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testMultiplication.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testMultiplication.st
@@ -1,11 +1,10 @@
 testing
 testMultiplication
 	| fd |
-
 	fd := FixedDecimal newFromNumber: 18.25 scale: 2.
-	self assert: ('36.50' = (fd * (2 asFixedDecimal: 2)) printString).
-	self assert: ('36.50' = (fd * 2.00) printString).
-	self assert: ('36.50' = (fd * (200/100)) printString).
-	self assert: ('36.50' = (fd * 2) printString).
-	self assert: ('-36.50' = (fd * -2) printString).
-	self assert: ('73.00' = (fd * 4) printString).
+	self assert: '36.50' equals: (fd * (2 asFixedDecimal: 2)) printString.
+	self assert: '36.50' equals: (fd * 2.00) printString.
+	self assert: '36.50' equals: (fd * (200 / 100)) printString.
+	self assert: '36.50' equals: (fd * 2) printString.
+	self assert: '-36.50' equals: (fd * -2) printString.
+	self assert: '73.00' equals: (fd * 4) printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testNegation.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testNegation.st
@@ -1,8 +1,7 @@
 testing
 testNegation
 	| original negated |
-	
-	original := 53/10 asFixedDecimal: 2.
+	original := 53 / 10 asFixedDecimal: 2.
 	negated := original negated.
 	self assert: original ~~ negated.
-	self assert: original = (negated negated).
+	self assert: original equals: negated negated

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testPrintString.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testPrintString.st
@@ -4,9 +4,9 @@ testPrintString
 	This is not compatible with the way ScaledDecimal printing works in Squeak."
 
 	| fd |
-	fd := FixedDecimal newFromNumber: (13 / 11) scale: 6.
-	self assert: ('1.181818' = fd printString).
-	fd := (13 / 11) asFixedDecimal: 5.
-	self assert: ('1.18182' = fd printString).
-	fd := FixedDecimal newFromNumber: (13 / 11) scale: 5.
-	self deny: ('1.18181' = fd printString)
+	fd := FixedDecimal newFromNumber: 13 / 11 scale: 6.
+	self assert: '1.181818' equals: fd printString.
+	fd := 13 / 11 asFixedDecimal: 5.
+	self assert: '1.18182' equals: fd printString.
+	fd := FixedDecimal newFromNumber: 13 / 11 scale: 5.
+	self deny: '1.18181' equals: fd printString

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testReciprocal.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testReciprocal.st
@@ -1,14 +1,13 @@
 testing
 testReciprocal
 	| original reciprocal |
-	
-	original := (8872240531573379/9007199254740992) asFixedDecimal: 35.
+	original := 8872240531573379 / 9007199254740992 asFixedDecimal: 35.
 	reciprocal := original reciprocal.
 	self assert: original ~~ reciprocal.
 	self assert: original ~= reciprocal.
-	self assert: 0 = (original * reciprocal - 1).
-	original := (1/3) asFixedDecimal: 6.
+	self assert: 0 equals: original * reciprocal - 1.
+	original := 1 / 3 asFixedDecimal: 6.
 	reciprocal := original reciprocal.
 	self assert: original ~~ reciprocal.
 	self assert: original ~= reciprocal.
-	self assert: 0 = (original * reciprocal - 1).
+	self assert: 0 equals: original * reciprocal - 1

--- a/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testSubtraction.st
+++ b/repository/FixedDecimal Tests.package/FixedDecimalTest.class/instance/testSubtraction.st
@@ -1,10 +1,11 @@
 testing
 testSubtraction
 	| fd |
-
 	fd := FixedDecimal newFromNumber: 18.25 scale: 2.
-	self assert: ('17.00' = (fd - (1.25 asFixedDecimal: 2)) printString).
-	self assert: ('17.00' = (fd - 1.25) printString).
-	self assert: ('17.00' = (fd - (125/100)) printString).
-	self assert: ('17.25' = (fd - 1) printString).
-	self assert: ('19.25' = (fd - -1) printString).
+	self
+		assert: '17.00'
+		equals: (fd - (1.25 asFixedDecimal: 2)) printString.
+	self assert: '17.00' equals: (fd - 1.25) printString.
+	self assert: '17.00' equals: (fd - (125 / 100)) printString.
+	self assert: '17.25' equals: (fd - 1) printString.
+	self assert: '19.25' equals: (fd - -1) printString


### PR DESCRIPTION
- convert unit test syntax to use assert: equals: instead of assert: =
- fix unit-test in testAdoption by converting ByteString '1' to  be FixedDecimal before testing (test was failing)